### PR TITLE
fix: set force true so that log can be override

### DIFF
--- a/oc_logging/wrapper.py
+++ b/oc_logging/wrapper.py
@@ -153,7 +153,8 @@ class StructlogWrapper:
         logging.basicConfig(
             level=self.log_level.value,
             format="%(message)s",  # structlog handles formatting
-            handlers=[logging.StreamHandler()]
+            handlers=[logging.StreamHandler()],
+            force = True
         )
 
         # Configure structlog

--- a/oc_logging/wrapper.py
+++ b/oc_logging/wrapper.py
@@ -148,13 +148,17 @@ class StructlogWrapper:
 
     def configure(self):
         """Configure structlog with the specified settings"""
+        # Since force=true only available for python3.8+, here is workaround to remove all handler first for fresh log settings
+        root = logging.getLogger()
+        if root.handlers:
+            for handler in root.handlers[:]:
+                root.removeHandler(handler)
 
         # Configure standard library logging since structlog is a logging wrapper
         logging.basicConfig(
             level=self.log_level.value,
             format="%(message)s",  # structlog handles formatting
-            handlers=[logging.StreamHandler()],
-            force = True
+            handlers=[logging.StreamHandler()]
         )
 
         # Configure structlog

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-__version = "1.1.5"
+__version = "1.1.6"
 install_requires = [
     "requests",
     "packaging",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-__version = "1.1.6"
+__version = "1.1.7"
 install_requires = [
     "requests",
     "packaging",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure logging updates are applied reliably by resetting existing root handlers before reconfiguring, preventing stale handlers and ignored updates.
* **Chores**
  * Version bumped to 1.1.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->